### PR TITLE
Fix memory request schema, health period and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ curl https://<your-service>.onrender.com/healthcheck
 curl -X POST -H "Content-Type: application/json" \
      -d '{"user_msg":"おはよう、体調どう？"}' \
      https://<your-service>.onrender.com/chat
+curl -X POST -H "Content-Type: application/json" \
+     -d '{"title":"眠い","summary":"会議中にウトウトした"}' \
+     http://localhost:8000/memory
+```

--- a/monday_secretary/app.py
+++ b/monday_secretary/app.py
@@ -8,13 +8,16 @@ Exposes:
   POST /memory        – Notion に記憶保存
 """
 
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.responses import JSONResponse
+from fastapi.exceptions import RequestValidationError
 from pydantic import BaseModel
-from typing import Any
 
 from .main_handler import handle_message
 from .models import (
-    HealthRequest, CalendarRequest, MemoryRequest,
+    HealthRequest,
+    CalendarRequest,
+    MemoryRequest,
     MemorySearchRequest,
 )
 from .clients.health import HealthClient
@@ -24,17 +27,32 @@ from .clients.calendar import CalendarClient
 from .clients.memory import MemoryClient
 import os
 from .clients.acceptance import AcceptanceClient
-from .models import AcceptanceRequest 
-from .utils.pending_memory import pop_pending
-import logging
+from .models import AcceptanceRequest
 import logging
 import traceback
 
+logger = logging.getLogger(__name__)
+
 app = FastAPI(title="Monday Secretary API")
+
+
+async def general_exception_handler(request: Request, exc: Exception):
+    logger.exception("unhandled error")
+    return JSONResponse(status_code=500, content={"detail": "internal server error"})
+
+
+async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    return JSONResponse(status_code=422, content={"detail": exc.errors()})
+
+
+app.add_exception_handler(Exception, general_exception_handler)
+app.add_exception_handler(RequestValidationError, validation_exception_handler)
+
 
 # ---------- Chat (既存) ----------
 class ChatRequest(BaseModel):
     user_msg: str
+
 
 @app.post("/chat")
 async def chat(req: ChatRequest):
@@ -44,6 +62,7 @@ async def chat(req: ChatRequest):
     except Exception as e:  # pragma: no cover
         raise HTTPException(status_code=500, detail=str(e))
 
+
 # ---------- Health ----------
 @app.post("/health")
 async def health_api(req: HealthRequest):
@@ -52,24 +71,24 @@ async def health_api(req: HealthRequest):
     try:
         match req.mode:
             case "latest":
-                data = await client.latest() 
+                data = await client.latest()
             case "compare":
                 data = await client.compare()
             case "period":
-                data = await client.period(req.start_date, req.end_date) 
+                data = await client.period(req.start_date, req.end_date)
             case "dailySummary":
-                data = await client.daily_summary(
-                    req.start_date or client.today
-                )
+                data = await client.daily_summary(req.start_date or client.today)
         return data
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
 
 # OpenAPI alias
 @app.post("/functions/get_health_data", tags=["functions"])
 async def get_health_data_alias(req: HealthRequest):
     """OpenAPI 用エイリアス"""
     return await health_api(req)
+
 
 # ---------- Work ----------
 @app.post("/work")
@@ -96,6 +115,7 @@ async def work_api(req: WorkRequest):
 async def work_alias(req: WorkRequest):
     return await work_api(req)
 
+
 # ---------- Acceptance ----------
 @app.post("/acceptance")
 async def acceptance_api(req: AcceptanceRequest):
@@ -110,10 +130,12 @@ async def acceptance_api(req: AcceptanceRequest):
         logging.exception("acceptance_api failed")
         raise HTTPException(status_code=500, detail=str(e))
 
+
 # OpenAPI alias
 @app.post("/functions/get_acceptance_data", tags=["acceptance"])
 async def acceptance_alias(req: AcceptanceRequest):
     return await acceptance_api(req)
+
 
 # ---------- Calendar ----------
 @app.post("/calendar")
@@ -122,15 +144,13 @@ async def calendar_api(req: CalendarRequest):
     try:
         match req.action:
             case "insert":
-                data = await client.insert_event(          # ← await 追加
+                data = await client.insert_event(  # ← await 追加
                     req.summary, req.start, req.end
                 )
             case "get":
-                data = await client.get_events(            # ← await
-                    req.start, req.end
-                )
+                data = await client.get_events(req.start, req.end)  # ← await
             case "update":
-                data = await client.update_event(          # ← await
+                data = await client.update_event(  # ← await
                     req.event_id, req.summary, req.start, req.end
                 )
             case "delete":
@@ -138,31 +158,31 @@ async def calendar_api(req: CalendarRequest):
         return data or {"status": "ok"}
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
-      
+
+
 # OpenAPI alias
 @app.post("/functions/calendar_event", tags=["functions"])
 async def calendar_event_alias(req: CalendarRequest):
     return await calendar_api(req)
 
+
 # ---------- Memory ----------
 @app.post("/memory", tags=["memory"])
 async def memory_api(req: MemoryRequest):
-    page = await MemoryClient().create_record(req.model_dump())
+    payload = req.model_dump()
+    payload.setdefault("category", "その他")
+    payload.setdefault("emotion", "嬉しい")
+    payload.setdefault("reason", "")
+    page = await MemoryClient().create_record(payload)
     return {"inserted": page["id"]}
+
 
 @app.post("/functions/create_memory", tags=["functions"])
 async def create_memory_fn(req: MemoryRequest):
     return await memory_api(req)
 
-# ---------- Memory confirm ----------
-@app.post("/memory", tags=["memory"])
-async def memory_api(req: MemoryRequest):
-    if not summary:
-        raise HTTPException(404, "no pending memory")
-    payload = build_memory_payload(summary)
-    page = await MemoryClient().create_record(payload)
-    return {"inserted": page["id"]}
 
+# ---------- Memory search ----------
 @app.post("/functions/get_memory", tags=["functions"])
 async def get_memory_alias(req: MemorySearchRequest):
     try:

--- a/monday_secretary/models.py
+++ b/monday_secretary/models.py
@@ -3,24 +3,28 @@ from typing import Optional, Literal
 
 from pydantic import BaseModel, Field
 
+
 # ---------- 体調 ----------
 class HealthRequest(BaseModel):
     sheet_url: Optional[str] = None
     mode: Literal["latest", "compare", "period", "dailySummary"] = "latest"
     start_date: Optional[date] = None
-    end_date:   Optional[date] = None
+    end_date: Optional[date] = None
+
 
 # ---------- 業務 ----------
 class WorkRequest(BaseModel):
     mode: Literal["latest", "period"] = "latest"
     start_date: Optional[date] = None
-    end_date:   Optional[date] = None
+    end_date: Optional[date] = None
+
 
 # ---------- Acceptance（自己受容） ----------
 class AcceptanceRequest(BaseModel):
     mode: Literal["latest", "period"]
     start_date: Optional[date] = None
-    end_date: Optional[date]   = None
+    end_date: Optional[date] = None
+
 
 class AcceptanceItem(BaseModel):
     タイムスタンプ: date
@@ -31,26 +35,27 @@ class AcceptanceItem(BaseModel):
     今日_自分を受け入れられた_瞬間はある: Optional[str] = None
     書き残しておきたいこと: Optional[str] = None
 
+
 # ---------- カレンダー ----------
 class CalendarRequest(BaseModel):
     action: Literal["insert", "get", "update", "delete"]
     calendar_id: Optional[str] = None
-    summary:     Optional[str] = None
-    start:       Optional[datetime] = None
-    end:         Optional[datetime] = None
-    event_id:    Optional[str] = None
+    summary: Optional[str] = None
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    event_id: Optional[str] = None
+
 
 # ---------- 記憶 ----------
 class MemoryRequest(BaseModel):
     title: str
     summary: str
-    category: Literal[
-        "スケジュール","創作","体調","仕事","遊び","思い出","感情","思考","その他"
-    ]
-    emotion: Literal["嬉しい","悲しい","怒り","楽しい","悔しい","辛い"]
-    reason: str
+    category: str = ""
+    emotion: str = ""
+    reason: str = ""
     timestamp: datetime = Field(default_factory=datetime.now)
 
+
 class MemorySearchRequest(BaseModel):
-    query: str = ""        # 空なら最新順
-    top_k: int = 5         # 何件返すか
+    query: str = ""  # 空なら最新順
+    top_k: int = 5  # 何件返すか


### PR DESCRIPTION
## Summary
- relax `MemoryRequest` to only require `title` and `summary`
- supply default values for optional memory fields in API
- add `_to_date` utility and fix date comparison in `HealthClient.period`
- add global exception handlers for internal and validation errors
- document minimal `/memory` payload

## Testing
- `pytest -q`
- `uvicorn monday_secretary.app:app --port 8000 --log-level warning &` *(fails to reach external services)*

------
https://chatgpt.com/codex/tasks/task_e_68522076e53483308f45baf51a75db1b