### PR TITLE
Fix memory request handling and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,5 @@ curl -X POST -H "Content-Type: application/json" \
      https://<your-service>.onrender.com/chat
 curl -X POST -H "Content-Type: application/json" \
      -d '{"title":"眠い","summary":"会議中にウトウトした"}' \
-     http://localhost:8000/memory
+     http://localhost:8000/functions/create_memory
 ```

--- a/monday_secretary/app.py
+++ b/monday_secretary/app.py
@@ -42,6 +42,7 @@ async def general_exception_handler(request: Request, exc: Exception):
 
 
 async def validation_exception_handler(request: Request, exc: RequestValidationError):
+    logger.exception("validation error")
     return JSONResponse(status_code=422, content={"detail": exc.errors()})
 
 

--- a/monday_secretary/clients/health.py
+++ b/monday_secretary/clients/health.py
@@ -18,8 +18,10 @@ class HealthClient:
         return await asyncio.to_thread(func, *args, **kwargs)
 
     @staticmethod
-    def _to_date(s: str) -> date:
+    def _to_date(s: str | date) -> date:
         """'YYYY/MM/DD' or 'YYYY-MM-DD' -> date"""
+        if isinstance(s, date):
+            return s
         return datetime.fromisoformat(s.replace("/", "-")).date()
 
     @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))

--- a/monday_secretary/clients/memory.py
+++ b/monday_secretary/clients/memory.py
@@ -16,8 +16,8 @@ class MemoryClient:
 
         # DB のカラム名を列挙しておくと安全
         self.valid_props: set[str] = {
-            "Title", "Summary", "Category",
-            "Emotion", "Reason", "Timestamp"
+            "タイトル", "要約", "カテゴリ",
+            "感情", "理由", "タイムスタンプ"
         }
 
     # ---------- 共通ユーティリティ ----------
@@ -34,18 +34,21 @@ class MemoryClient:
             if name in self.valid_props:
                 props[name] = value
 
-        add("Title", {
+        add("タイトル", {
             "title": [{"text": {"content": payload["title"]}}]
         })
-        add("Summary", {
+        add("要約", {
             "rich_text": [{"text": {"content": payload["summary"]}}]
         })
-        add("Category", {"select": {"name": payload["category"]}})
-        add("Emotion",  {"select": {"name": payload["emotion"]}})
-        add("Reason", {
-            "rich_text": [{"text": {"content": payload["reason"]}}]
-        })
-        add("Timestamp", {
+        if payload.get("category"):
+            add("カテゴリ", {"select": {"name": payload["category"]}})
+        if payload.get("emotion"):
+            add("感情",  {"select": {"name": payload["emotion"]}})
+        if payload.get("reason"):
+            add("理由", {
+                "rich_text": [{"text": {"content": payload["reason"]}}]
+            })
+        add("タイムスタンプ", {
             "date": {
                 "start": (
                     payload.get("timestamp") or datetime.utcnow()

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -86,6 +86,33 @@ paths:
               schema:
                 $ref: "#/components/schemas/CalendarResponse"
 
+  # ─── Memory ────────────────────────────
+  /functions/create_memory:
+    post:
+      operationId: createMemory
+      summary: メモを保存
+      tags: [Memory]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/MemoryRequest"
+            example:
+              title: "眠い"
+              summary: "会議中にウトウトした"
+      responses:
+        "200":
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  inserted:
+                    type: string
+
+
 components:
   schemas:
     # ---------- Health ----------
@@ -237,3 +264,14 @@ components:
         status: { type: string, example: "success" }
         event:
           $ref: "#/components/schemas/CalendarEvent"
+
+    # ---------- Memory ----------
+    MemoryRequest:
+      type: object
+      required: [title, summary]
+      properties:
+        title: { type: string }
+        summary: { type: string }
+        category: { type: string, nullable: true }
+        emotion: { type: string, nullable: true }
+        reason: { type: string, nullable: true }

--- a/tests/test_health_client.py
+++ b/tests/test_health_client.py
@@ -1,0 +1,25 @@
+import os
+import sys
+import asyncio
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+from monday_secretary.clients.health import HealthClient
+
+class DummySheet:
+    def get_all_records(self):
+        return [
+            {"タイムスタンプ": "2025-06-10", "睡眠時間": 6},
+            {"タイムスタンプ": "2025-06-11", "睡眠時間": 7},
+            {"タイムスタンプ": "2025-06-12", "睡眠時間": 5},
+        ]
+
+@pytest.mark.asyncio
+async def test_period_slice(monkeypatch):
+    hc = object.__new__(HealthClient)
+    hc.sheet = DummySheet()
+    async def dummy_thread(func, *a, **kw):
+        return func(*a, **kw)
+    monkeypatch.setattr(hc, "_to_thread", dummy_thread)
+    result = await HealthClient.period(hc, "2025-06-11", "2025-06-12")
+    assert len(result) == 2


### PR DESCRIPTION
## Summary
- handle missing optional fields when storing memories
- log validation errors
- fix `HealthClient.period` date conversion
- document `/functions/create_memory` endpoint
- example calls updated in README
- add unit test for health period slicing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68522dca09708330a6b653f1f68e13c5