### PR TITLE
Fix morning trigger loop issue

### DIFF
--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -19,7 +19,7 @@ async def test_morning_trigger(monkeypatch):
 
     class DummyCal:
         async def get_events(self, start, end):
-            return [{"summary": "会議"}]
+            return [{"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}}]
 
     class DummyWork:
         async def latest(self):
@@ -28,7 +28,11 @@ async def test_morning_trigger(monkeypatch):
     monkeypatch.setattr("monday_secretary.main_handler.HealthClient", DummyHealth)
     monkeypatch.setattr("monday_secretary.main_handler.CalendarClient", DummyCal)
     monkeypatch.setattr("monday_secretary.main_handler.WorkClient", DummyWork)
+    monkeypatch.setattr("monday_secretary.main_handler.AcceptanceClient", lambda: None)
     monkeypatch.setattr("monday_secretary.main_handler.BrakeChecker.check", lambda self, h, w={}: DummyBrake(1))
+    from monday_secretary import main_handler
+    main_handler.MORNING_LOCKS.clear()
+    main_handler.LAST_MORNING.clear()
 
     reply = await handle_message("おはよう！")
     assert "**Monday**" in reply
@@ -49,6 +53,10 @@ async def test_normal_flow(monkeypatch):
     monkeypatch.setattr("monday_secretary.main_handler.HealthClient", DummyHealth)
     monkeypatch.setattr("monday_secretary.main_handler.WorkClient", DummyWork)
     monkeypatch.setattr("monday_secretary.main_handler.BrakeChecker.check", lambda self, h, w={}: DummyBrake(1))
+    from monday_secretary import main_handler
+    main_handler.MORNING_LOCKS.clear()
+    main_handler.LAST_MORNING.clear()
+    monkeypatch.setattr("monday_secretary.main_handler.AcceptanceClient", lambda: None)
 
     reply = await handle_message("今日の体調教えて")
     assert "<CONTEXT>" in reply


### PR DESCRIPTION
## Summary
- prevent repeated morning trigger execution using asyncio.Lock and cooldown
- fallback to default YAML filename and `keywords` field
- improve health detail fallback logic
- update tests with dummy start time and reset morning state

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852345da51c8330b17acc0d21b20a3e