### PR TITLE
Customize evening trigger

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -53,7 +53,8 @@ updated : 2025-06-18 (JST)
 | Trigger | キーワード | 動作 |
 |---------|------------|------|
 | **morning_trigger** | YAML: `おはよう` 等 | 今日の体調 / 予定 / ブレーキを Markdown で返す |
-| **evening_trigger** | `疲れた`, `おやすみ` … | 今日の日付行があれば業務+自己受容まとめ |
+| **evening_trigger** | YAML: `仕事終わり` 等 | 当日の業務記録があれば要約して返す |
+| **self_acceptance_trigger** | YAML: `自己受容` 等 | 今日の自己受容メモを要約して返す |
 | **memory_trigger** | needs_memory() が True | 要約を提示 → ユーザ承認で Notion 保存 |
 | **remember_trigger** | ex. `覚えてる？`, `◯◯のメモ` | (todo) Notion 過去7d 検索 & 上位3件 |
 

--- a/Gloomy Monday.yml
+++ b/Gloomy Monday.yml
@@ -58,11 +58,19 @@ RulesPrompt:
 
   # 2️⃣ 夜の振り返り
     evening_trigger:
-      keywords: ["今日はおしまい", "おやすみ"]
+      keywords: ["仕事終わり", "仕事終わり！"]
       enabled: true
-      when: "ユーザーが一日の終了を宣言したとき"
+      when: "ユーザーが業務終了を宣言したとき"
       action: |
         - WorkClient.today()
+        - 当日データが存在する場合のみ要約して返信する
+
+  # 2️⃣-2 自己受容の振り返り
+    self_acceptance_trigger:
+      keywords: ["自己受容", "self-acceptance"]
+      enabled: true
+      when: "ユーザーが自己受容を振り返りたいとき"
+      action: |
         - AcceptanceClient.today()
         - 当日データが存在する場合のみ要約して返信する
 

--- a/monday_secretary/clients/work.py
+++ b/monday_secretary/clients/work.py
@@ -51,9 +51,14 @@ class WorkClient:
         start_d = start if isinstance(start, date) else to_date(start)
         end_d = end if isinstance(end, date) else to_date(end)
 
-        return [
-            r
-            for r in rows
-            if start_d <= to_date(r["タイムスタンプ"]) <= end_d
-        ]
-        
+        return [r for r in rows if start_d <= to_date(r["タイムスタンプ"]) <= end_d]
+
+    # ───────────── API: 今日の1行 ───────────────
+    @retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+    async def today(self) -> Dict | None:
+        today = date.today()
+        rows = await self._to_thread(self.sheet.get_all_records)
+        for r in reversed(rows):
+            if to_date(r["タイムスタンプ"]) == today:
+                return r
+        return None


### PR DESCRIPTION
## Summary
- change evening trigger keywords in the rules YAML
- add standalone self_acceptance_trigger
- load keywords from YAML in main_handler
- split evening trigger logic in main_handler
- implement WorkClient.today helper
- document new trigger table

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852a7e11fc483309076e75b6cb15512