### PR TITLE
Fix OAuth2 callback Flow initialization

### DIFF
--- a/monday_secretary/app.py
+++ b/monday_secretary/app.py
@@ -183,9 +183,16 @@ async def oauth2callback(request: Request):
     client_secret = os.getenv("GOOGLE_TASKS_CLIENT_SECRET")
     redirect_uri = "https://health-api-server.onrender.com/oauth2callback"
 
-    flow = Flow(
-        client_id=client_id,
-        client_secret=client_secret,
+    flow = Flow.from_client_config(
+        {
+            "installed": {
+                "client_id": client_id,
+                "client_secret": client_secret,
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+                "redirect_uris": [redirect_uri],
+            }
+        },
         scopes=["https://www.googleapis.com/auth/tasks"],
         redirect_uri=redirect_uri,
     )


### PR DESCRIPTION
## Summary
- fix `oauth2callback` by using `Flow.from_client_config`
- provide auth and token URIs for Google OAuth2

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853d2b9a7f083308a34bef91f7a356a