### PR TITLE
Add env var checks for Tasks client

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ curl -X POST -H "Content-Type: application/json" \
     http://localhost:8000/tasks
 ```
 
+### Google Tasks client example
+
+```python
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+import os
+
+creds = Credentials(
+    None,
+    refresh_token=os.getenv("GOOGLE_TASKS_REFRESH_TOKEN"),
+    token_uri="https://oauth2.googleapis.com/token",
+    client_id=os.getenv("GOOGLE_OAUTH_CLIENT_ID"),
+    client_secret=os.getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
+    scopes=["https://www.googleapis.com/auth/tasks"],
+)
+
+service = build("tasks", "v1", credentials=creds)
+print(service.tasklists().list().execute())
+```
+
 ### Client utilities
 
 Each API client inherits from `BaseClient` which provides a helper

--- a/monday_secretary/clients/tasks.py
+++ b/monday_secretary/clients/tasks.py
@@ -10,13 +10,25 @@ class TasksClient(BaseClient):
     """Minimal wrapper for Google Tasks API."""
 
     def __init__(self):
+        refresh_token = os.getenv("GOOGLE_TASKS_REFRESH_TOKEN")
+        client_id = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
+        client_secret = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
+
+        if not (refresh_token and client_id and client_secret):
+            raise RuntimeError(
+                "Missing env vars: GOOGLE_TASKS_REFRESH_TOKEN, "
+                "GOOGLE_OAUTH_CLIENT_ID, GOOGLE_OAUTH_CLIENT_SECRET"
+            )
+
         self.creds = Credentials(
             None,
-            refresh_token=os.getenv("GOOGLE_TASKS_REFRESH_TOKEN"),
-            client_id=os.getenv("GOOGLE_OAUTH_CLIENT_ID"),
-            client_secret=os.getenv("GOOGLE_OAUTH_CLIENT_SECRET"),
+            refresh_token=refresh_token,
+            client_id=client_id,
+            client_secret=client_secret,
             token_uri="https://oauth2.googleapis.com/token",
+            scopes=["https://www.googleapis.com/auth/tasks"],
         )
+
         self.service = build("tasks", "v1", credentials=self.creds)
         self.tasklist = os.getenv("GOOGLE_TASKS_LIST_ID", "@default")
 


### PR DESCRIPTION
## Summary
- validate Google Tasks credentials via env vars and add scopes
- document a Google Tasks client example in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541ca192c08330a39e7607f19e70a2