### PR TITLE
Add weekend review summary

### DIFF
--- a/Gloomy Monday.yml
+++ b/Gloomy Monday.yml
@@ -87,6 +87,19 @@ RulesPrompt:
         - MemoryClient.search(query)
         - ヒットしたメモを Monday の口調で語り直す
 
+  # 5️⃣ 週末整理
+    weekend_trigger:
+      keywords: ["週末整理", "今週終わり", "weekend"]
+      enabled: true
+      when: "金曜の業務終了後、1週間を振り返りたいとき"
+      action: |
+        - TasksClient.list_tasks()             # 未完タスクを取得
+        - CalendarClient.get_events(last_week) # 実行済みイベントログ
+        - HealthClient.period(last_week)
+        - WorkClient.period(last_week)
+        - 未完タスクはタグごとに整理
+        - スケジュール・体調・業務の変化を要約表示
+
 # JudgeCore_FactCheck
 # --- Judge ------------------------------------------
 JudgeCore:

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ curl -X POST -H "Content-Type: application/json" \
     http://localhost:8000/tasks
 ```
 
+### Weekend cleanup
+
+Running `handle_message("週末整理して")` will collect this week's events,
+unfinished tasks, health logs and work summaries. It helps review progress
+before planning the next week.
+
 ### Google Tasks client example
 
 ```python

--- a/monday_secretary/main_handler.py
+++ b/monday_secretary/main_handler.py
@@ -9,6 +9,7 @@ from .clients import (
     WorkClient,
     CalendarClient,
     MemoryClient,
+    TasksClient,
 )
 from .utils.brake_checker import BrakeChecker
 from .utils.memory_suggester import needs_memory
@@ -33,6 +34,12 @@ EVENING_KWS = (
     CFG.get("RulesPrompt", {})
     .get("Triggers", {})
     .get("evening_trigger", {})
+    .get("keywords", [])
+)
+WEEKEND_KWS = (
+    CFG.get("RulesPrompt", {})
+    .get("Triggers", {})
+    .get("weekend_trigger", {})
     .get("keywords", [])
 )
 REMEMBER_KWS = ["覚えてる？", "思い出して", "あの時の記憶", "過去メモ"]
@@ -152,6 +159,62 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
             "**Monday**：今日もお疲れさま！\n"
             f"🗒 **業務まとめ**：{work_today.get('今日のまとめ！', '—') if work_today else '（記録なし）'}"
         )
+
+    # ──────────── 2.5) weekend_trigger ─────────────
+    if any(k in user_msg for k in WEEKEND_KWS):
+        start = dt.date.today() - dt.timedelta(days=6)
+        end = dt.date.today()
+
+        tasks = await TasksClient().list_tasks()
+        events = await CalendarClient().get_events(
+            f"{start}T00:00:00Z", f"{end}T23:59:59Z"
+        )
+        health = await HealthClient().period(start, end)
+        works = await WorkClient().period(start, end)
+
+        groups: Dict[str, List[str]] = {}
+        for t in tasks:
+            notes = t.get("notes", "")
+            tags = [w[1:] for w in notes.split() if w.startswith("#")]
+            if not tags:
+                tags = ["その他"]
+            line = f"{t.get('title')} ({t.get('due', '-')[:10]})"
+            for tg in tags:
+                groups.setdefault(tg, []).append(line)
+
+        task_lines = []
+        for tag, items in groups.items():
+            task_lines.append(f"- **#{tag}**")
+            for it in items:
+                task_lines.append(f"  - {it}")
+
+        event_lines = [
+            f"- {e['summary']} ({e['start']['dateTime'][:10]})" for e in events
+        ] or ["- （イベントなし）"]
+
+        health_lines = [
+            f"- {h.get('timestamp', '')[:10]} {h.get('mood', h.get('状態', ''))}"
+            for h in health
+        ] or ["- （データなし）"]
+
+        work_lines = [
+            f"- {w.get('timestamp', '')[:10]} {w.get('daily_summary', '')}"
+            for w in works
+        ] or ["- （記録なし）"]
+
+        summary = (
+            "**Monday**：週末整理の時間だよ。\n\n"
+            "### 📝 未完タスク\n"
+            + "\n".join(task_lines)
+            + "\n\n### 📅 今週のイベント\n"
+            + "\n".join(event_lines)
+            + "\n\n### 🩺 体調ログ\n"
+            + "\n".join(health_lines)
+            + "\n\n### 🗒 業務ログ\n"
+            + "\n".join(work_lines)
+            + "\n\n削除・延期・予定化・そのまま、どうするか教えてね。"
+        )
+        return summary
 
 
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Monday Secretary API
-  version: 1.1.3
+  version: 1.1.4
 servers:
   - url: https://health-api-server.onrender.com
 paths:


### PR DESCRIPTION
## Summary
- extend weekend_trigger config to cover health and work logs
- enhance weekend_trigger implementation to fetch past week's tasks, events, health and work records
- document weekend cleanup usage in README
- bump API version to 1.1.4

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68541ea2da68833097194b3dc0cefe2d