### PR TITLE
Add calendar service account support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ pip install -r requirements.txt
 Create a `.env` file with the following variables:
 
 - `GOOGLE_SA_JSON_PATH`
+- `GOOGLE_CAL_SA_JSON_PATH` (optional)
 - `SHEET_URL`
 - `GOOGLE_CLIENT_ID`
 - `GOOGLE_CLIENT_SECRET`

--- a/monday_secretary/clients/calendar.py
+++ b/monday_secretary/clients/calendar.py
@@ -1,5 +1,6 @@
 import os
 from google.oauth2.credentials import Credentials
+from google.oauth2.service_account import Credentials as SACredentials
 from googleapiclient.discovery import build
 
 from .base import BaseClient, DEFAULT_RETRY
@@ -9,13 +10,19 @@ class CalendarClient(BaseClient):
     """Access Google Calendar API."""
 
     def __init__(self):
-        self.creds = Credentials(
-            None,
-            refresh_token=os.getenv("GOOGLE_REFRESH_TOKEN"),
-            client_id=os.getenv("GOOGLE_CLIENT_ID"),
-            client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
-            token_uri="https://oauth2.googleapis.com/token",
-        )
+        sa_path = os.getenv("GOOGLE_CAL_SA_JSON_PATH")
+        if sa_path:
+            self.creds = SACredentials.from_service_account_file(
+                sa_path, scopes=["https://www.googleapis.com/auth/calendar"]
+            )
+        else:
+            self.creds = Credentials(
+                None,
+                refresh_token=os.getenv("GOOGLE_REFRESH_TOKEN"),
+                client_id=os.getenv("GOOGLE_CLIENT_ID"),
+                client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
+                token_uri="https://oauth2.googleapis.com/token",
+            )
         self.service = build("calendar", "v3", credentials=self.creds)
 
 


### PR DESCRIPTION
## Summary
- support `GOOGLE_CAL_SA_JSON_PATH` for Google Calendar
- document the new optional variable in the setup guide

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6854264bfb4c8330bead6f73b160be2b