### PR TITLE
Unify SA_PATH & scopes

### DIFF
--- a/monday_secretary/clients/base.py
+++ b/monday_secretary/clients/base.py
@@ -1,4 +1,6 @@
 import asyncio
+import os
+from google.oauth2 import service_account
 from tenacity import retry, wait_fixed, stop_after_attempt
 
 class BaseClient:
@@ -9,4 +11,11 @@ class BaseClient:
         return await asyncio.to_thread(func, *args, **kwargs)
 
 DEFAULT_RETRY = retry(wait=wait_fixed(2), stop=stop_after_attempt(3))
+
+# -- Google Service Account path & scopes -----------------------------------
+SA_PATH = os.getenv("GOOGLE_SA_JSON_PATH")
+
+SCOPES_SHEETS = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+SCOPES_CALENDAR = ["https://www.googleapis.com/auth/calendar"]
+SCOPES_ALL = SCOPES_SHEETS + SCOPES_CALENDAR
 

--- a/monday_secretary/clients/calendar.py
+++ b/monday_secretary/clients/calendar.py
@@ -1,28 +1,23 @@
 import os
-from google.oauth2.credentials import Credentials
-from google.oauth2.service_account import Credentials as SACredentials
 from googleapiclient.discovery import build
+from google.oauth2 import service_account
 
-from .base import BaseClient, DEFAULT_RETRY
+from .base import (
+    BaseClient,
+    DEFAULT_RETRY,
+    SA_PATH,
+    SCOPES_CALENDAR,
+)
 
 
 class CalendarClient(BaseClient):
     """Access Google Calendar API."""
 
     def __init__(self):
-        sa_path = os.getenv("GOOGLE_CAL_SA_JSON_PATH")
-        if sa_path:
-            self.creds = SACredentials.from_service_account_file(
-                sa_path, scopes=["https://www.googleapis.com/auth/calendar"]
-            )
-        else:
-            self.creds = Credentials(
-                None,
-                refresh_token=os.getenv("GOOGLE_REFRESH_TOKEN"),
-                client_id=os.getenv("GOOGLE_CLIENT_ID"),
-                client_secret=os.getenv("GOOGLE_CLIENT_SECRET"),
-                token_uri="https://oauth2.googleapis.com/token",
-            )
+        self.creds = service_account.Credentials.from_service_account_file(
+            SA_PATH,
+            scopes=SCOPES_CALENDAR,
+        )
         self.service = build("calendar", "v3", credentials=self.creds)
 
 

--- a/monday_secretary/clients/health.py
+++ b/monday_secretary/clients/health.py
@@ -1,17 +1,20 @@
 import os
 from datetime import date, datetime
 import gspread
+from google.oauth2 import service_account
 
-from .base import BaseClient, DEFAULT_RETRY
+from .base import BaseClient, DEFAULT_RETRY, SA_PATH, SCOPES_SHEETS
 
 
 class HealthClient(BaseClient):
     """Read health logs from Google Sheets."""
 
     def __init__(self):
-        sa_path = os.getenv("GOOGLE_SA_JSON_PATH")
         sheet_url = os.getenv("SHEET_URL")
-        self.gc = gspread.service_account(filename=sa_path)
+        self.creds = service_account.Credentials.from_service_account_file(
+            SA_PATH, scopes=SCOPES_SHEETS
+        )
+        self.gc = gspread.authorize(self.creds)
         self.sheet = self.gc.open_by_url(sheet_url).sheet1
 
 

--- a/monday_secretary/clients/work.py
+++ b/monday_secretary/clients/work.py
@@ -5,8 +5,9 @@ from datetime import date
 from typing import List, Dict
 
 import gspread
+from google.oauth2 import service_account
 
-from .base import BaseClient, DEFAULT_RETRY
+from .base import BaseClient, DEFAULT_RETRY, SA_PATH, SCOPES_SHEETS
 
 # 共通ヘルパ：文字列 → date 変換
 from monday_secretary.utils.date import to_date
@@ -16,10 +17,11 @@ class WorkClient(BaseClient):
     """Google シートの〈業務記録〉タブを読む軽量クライアント"""
 
     def __init__(self) -> None:
-        sa_path = os.getenv("GOOGLE_SA_JSON_PATH")
         sheet_url = os.getenv("SHEET_URL")
-
-        self.gc = gspread.service_account(filename=sa_path)
+        self.creds = service_account.Credentials.from_service_account_file(
+            SA_PATH, scopes=SCOPES_SHEETS
+        )
+        self.gc = gspread.authorize(self.creds)
         self.sheet = self.gc.open_by_url(sheet_url).worksheet("業務記録")
 
 


### PR DESCRIPTION
## Summary
- centralize service account path and scopes in `BaseClient`
- update `HealthClient` and `WorkClient` to use shared credentials
- update `CalendarClient` to use service account with calendar scopes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68542d5286f08330ab3456c44660a403