### PR TITLE
Handle all-day calendar events

### DIFF
--- a/monday_secretary/main_handler.py
+++ b/monday_secretary/main_handler.py
@@ -118,10 +118,15 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
 
             # ② 予定を箇条書き（なければ “なし”）
             if events:
-                today_events = "\n".join(
-                    f"　・{e['summary']}（{e['start']['dateTime'][11:16]}〜）"
-                    for e in events
-                )
+                lines = []
+                for e in events:
+                    start = e.get("start", {})
+                    if "dateTime" in start:
+                        time_text = start["dateTime"][11:16] + "〜"
+                    else:
+                        time_text = "終日"
+                    lines.append(f"　・{e['summary']}（{time_text}）")
+                today_events = "\n".join(lines)
             else:
                 today_events = "　（登録なし。フリータイム！）"
 
@@ -178,9 +183,13 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
         events = await CalendarClient().get_events(
             f"{start}T00:00:00Z", f"{end}T23:59:59Z"
         )
-        event_lines = [
-            f"- {e['summary']} ({e['start']['dateTime'][:10]})" for e in events
-        ] or ["- （イベントなし）"]
+        event_lines = []
+        for e in events:
+            start = e.get("start", {})
+            date_text = start.get("dateTime", start.get("date", ""))[:10]
+            event_lines.append(f"- {e['summary']} ({date_text})")
+        if not event_lines:
+            event_lines.append("- （イベントなし）")
 
         summary = (
             "**Monday**：週末整理の時間だよ。\n\n"

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -19,7 +19,10 @@ async def test_morning_trigger(monkeypatch):
 
     class DummyCal:
         async def get_events(self, start, end):
-            return [{"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}}]
+            return [
+                {"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}},
+                {"summary": "休暇", "start": {"date": "2025-06-18"}, "end": {"date": "2025-06-19"}},
+            ]
 
     class DummyWork:
         async def latest(self):
@@ -37,6 +40,8 @@ async def test_morning_trigger(monkeypatch):
     assert "**Monday**" in reply
     assert "良好" in reply
     assert "会議" in reply
+    assert "休暇" in reply
+    assert "終日" in reply
     assert "業務" not in reply
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- support Google Calendar all-day events in morning and weekend summaries
- update unit tests for all-day event handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fcfb98008330a8531147f49535cf