### PR TITLE
Handle timezone correctly when fetching calendar events

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,3 +87,7 @@ When an internal error occurs, the API returns a JSON body like:
 ```
 
 This helps with debugging failing requests.
+
+Validation errors now return a 422 status code with details, while unexpected
+errors are logged and returned as 500. Check the server logs if you need more
+information.

--- a/monday_secretary/clients/calendar.py
+++ b/monday_secretary/clients/calendar.py
@@ -22,13 +22,19 @@ class CalendarClient(BaseClient):
 
 
     @DEFAULT_RETRY
-    async def get_events(self, time_min: str, time_max: str) -> list:
+    async def get_events(self, time_min: str, time_max: str, tz: str | None = None) -> list:
         def _call():
-            events = (
-                self.service.events()
-                .list(calendarId="primary", timeMin=time_min, timeMax=time_max)
-                .execute()
-            )
+            params = {
+                "calendarId": "primary",
+                "timeMin": time_min,
+                "timeMax": time_max,
+                "singleEvents": True,
+                "orderBy": "startTime",
+            }
+            if tz:
+                params["timeZone"] = tz
+
+            events = self.service.events().list(**params).execute()
             return events.get("items", [])
 
         return await self._to_thread(_call)

--- a/monday_secretary/main_handler.py
+++ b/monday_secretary/main_handler.py
@@ -97,12 +97,13 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
             LAST_MORNING[session_id] = now
 
             today = dt.date.today().isoformat()
-            start_iso, end_iso = f"{today}T00:00:00Z", f"{today}T23:59:59Z"
+            start_iso = f"{today}T00:00:00+09:00"
+            end_iso = f"{today}T23:59:59+09:00"
 
             # Health・Calendar を並列取得
             health, events = await asyncio.gather(
                 health_client.latest(),
-                calendar_client.get_events(start_iso, end_iso),
+                calendar_client.get_events(start_iso, end_iso, "Asia/Tokyo"),
             )
 
             # ① 体調詳細を組み立て
@@ -118,10 +119,15 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
 
             # ② 予定を箇条書き（なければ “なし”）
             if events:
-                today_events = "\n".join(
-                    f"　・{e['summary']}（{e['start']['dateTime'][11:16]}〜）"
-                    for e in events
-                )
+                lines = []
+                for e in events:
+                    start = e.get("start", {})
+                    if "dateTime" in start:
+                        time_text = start["dateTime"][11:16] + "〜"
+                    else:
+                        time_text = "終日"
+                    lines.append(f"　・{e['summary']}（{time_text}）")
+                today_events = "\n".join(lines)
             else:
                 today_events = "　（登録なし。フリータイム！）"
 
@@ -176,11 +182,15 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
                 high_tasks.append(line)
 
         events = await CalendarClient().get_events(
-            f"{start}T00:00:00Z", f"{end}T23:59:59Z"
+            f"{start}T00:00:00+09:00", f"{end}T23:59:59+09:00", "Asia/Tokyo"
         )
-        event_lines = [
-            f"- {e['summary']} ({e['start']['dateTime'][:10]})" for e in events
-        ] or ["- （イベントなし）"]
+        event_lines = []
+        for e in events:
+            start = e.get("start", {})
+            date_text = start.get("dateTime", start.get("date", ""))[:10]
+            event_lines.append(f"- {e['summary']} ({date_text})")
+        if not event_lines:
+            event_lines.append("- （イベントなし）")
 
         summary = (
             "**Monday**：週末整理の時間だよ。\n\n"
@@ -224,8 +234,11 @@ async def handle_message(user_msg: str, session_id: str = "default") -> str:
 
 
     if "calendar" in user_msg:
-        now_iso = dt.datetime.utcnow().isoformat() + "Z"
-        context["events"] = await calendar_client.get_events(now_iso, now_iso)
+        tz = dt.timezone(dt.timedelta(hours=9))
+        now = dt.datetime.now(tz)
+        start_iso = now.isoformat()
+        end_iso = (now + dt.timedelta(days=1)).isoformat()
+        context["events"] = await calendar_client.get_events(start_iso, end_iso, "Asia/Tokyo")
 
     if "remember" in user_msg:
         context["memories"] = await memory_client.search(user_msg)

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -18,8 +18,11 @@ async def test_morning_trigger(monkeypatch):
             return {"状態": "良好"}
 
     class DummyCal:
-        async def get_events(self, start, end):
-            return [{"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}}]
+        async def get_events(self, start, end, tz=None):
+            return [
+                {"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}},
+                {"summary": "休暇", "start": {"date": "2025-06-18"}, "end": {"date": "2025-06-19"}},
+            ]
 
     class DummyWork:
         async def latest(self):
@@ -37,6 +40,8 @@ async def test_morning_trigger(monkeypatch):
     assert "**Monday**" in reply
     assert "良好" in reply
     assert "会議" in reply
+    assert "休暇" in reply
+    assert "終日" in reply
     assert "業務" not in reply
 
 @pytest.mark.asyncio
@@ -72,7 +77,7 @@ async def test_weekend_trigger(monkeypatch):
             ]
 
     class DummyCal:
-        async def get_events(self, start, end):
+        async def get_events(self, start, end, tz=None):
             return [
                 {"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}}
             ]


### PR DESCRIPTION
## Summary
- add optional timezone to `CalendarClient.get_events`
- request Tokyo timezone in handlers and expand range for current schedule
- adjust tests for updated method signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855fcfb98008330a8531147f49535cf