### PR TITLE
Fix calendar timezone handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ Each API client inherits from `BaseClient` which provides a helper
 method for running blocking SDK calls in a background thread. All network
 operations share the same retry logic via the `DEFAULT_RETRY` decorator.
 
+### Calendar notes
+
+`/calendar` and `CalendarClient.get_events()` accept `start` and `end` as
+`datetime` objects or ISO8601 strings.  When `datetime` objects are used and no
+timezone is attached, **Asia/Tokyo** is assumed.  The client converts these
+values to properly formatted strings before calling the Google Calendar API.
+
 ### Error responses
 
 When an internal error occurs, the API returns a JSON body like:

--- a/monday_secretary/clients/calendar.py
+++ b/monday_secretary/clients/calendar.py
@@ -1,5 +1,7 @@
 from googleapiclient.discovery import build
 from google.oauth2 import service_account
+from datetime import datetime
+from zoneinfo import ZoneInfo
 from .base import BaseClient, DEFAULT_RETRY, SA_PATH, SCOPES_CALENDAR
 
 class CalendarClient(BaseClient):
@@ -12,13 +14,21 @@ class CalendarClient(BaseClient):
         )
         self.service = build("calendar", "v3", credentials=self.creds)
 
+    def _to_iso(self, dt_or_str: datetime | str, tz: str) -> str:
+        """Convert datetime or string to ISO-8601 with timezone"""
+        if isinstance(dt_or_str, datetime):
+            if dt_or_str.tzinfo is None:
+                dt_or_str = dt_or_str.replace(tzinfo=ZoneInfo(tz))
+            return dt_or_str.isoformat()
+        return dt_or_str
+
     @DEFAULT_RETRY
-    async def get_events(self, time_min: str, time_max: str, tz: str = "Asia/Tokyo") -> list:
+    async def get_events(self, time_min: datetime | str, time_max: datetime | str, tz: str = "Asia/Tokyo") -> list:
         def _call():
             params = {
                 "calendarId": "primary",
-                "timeMin": time_min,
-                "timeMax": time_max,
+                "timeMin": self._to_iso(time_min, tz),
+                "timeMax": self._to_iso(time_max, tz),
                 "singleEvents": True,
                 "orderBy": "startTime",
                 "timeZone": tz,

--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -54,8 +54,13 @@ async def test_normal_flow(monkeypatch):
         async def latest(self):
             return {}
 
+    class DummyCal:
+        async def get_events(self, start, end, tz=None):
+            return []
+
     monkeypatch.setattr("monday_secretary.main_handler.HealthClient", DummyHealth)
     monkeypatch.setattr("monday_secretary.main_handler.WorkClient", DummyWork)
+    monkeypatch.setattr("monday_secretary.main_handler.CalendarClient", DummyCal)
     monkeypatch.setattr("monday_secretary.main_handler.BrakeChecker.check", lambda self, h, w={}: DummyBrake(1))
     from monday_secretary import main_handler
     main_handler.MORNING_LOCKS.clear()
@@ -90,8 +95,18 @@ async def test_weekend_trigger(monkeypatch):
                 {"summary": "来週会議", "start": {"dateTime": "2025-06-25T09:00:00"}}
             ]
 
+    class DummyHealth:
+        async def latest(self):
+            return {}
+
+    class DummyWork:
+        async def latest(self):
+            return {}
+
     monkeypatch.setattr("monday_secretary.main_handler.TasksClient", DummyTasks)
     monkeypatch.setattr("monday_secretary.main_handler.CalendarClient", DummyCal)
+    monkeypatch.setattr("monday_secretary.main_handler.HealthClient", DummyHealth)
+    monkeypatch.setattr("monday_secretary.main_handler.WorkClient", DummyWork)
 
     reply = await handle_message("週末整理して")
     assert "T1" in reply


### PR DESCRIPTION
## Summary
- handle timezone on `CalendarClient.get_events`
- clarify calendar timezone behavior in README
- adjust tests to mock Calendar client

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859e71cf60c83308a54a25ae3252c99