### PR TITLE
Add calendar example script

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ day (Asia/Tokyo) is used automatically.  When `datetime` objects are used and no
 timezone is attached, **Asia/Tokyo** is assumed.
 The client converts these values to properly formatted strings before calling the Google Calendar API.
 
+### Example: today's events
+
+If you just want to see the events scheduled for today (Asia/Tokyo), run the sample script in `examples/calendar_today.py`:
+
+```bash
+python examples/calendar_today.py
+```
+
+This will print the summaries of today's events to your console.
+
 ### Error responses
 
 When an internal error occurs, the API returns a JSON body like:

--- a/examples/calendar_today.py
+++ b/examples/calendar_today.py
@@ -1,0 +1,17 @@
+import asyncio
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+from monday_secretary.clients import CalendarClient
+
+async def main():
+    jst = ZoneInfo("Asia/Tokyo")
+    start = datetime.now(jst).replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1, seconds=-1)
+
+    client = CalendarClient()
+    events = await client.get_events(start, end)
+    for ev in events:
+        print(ev.get("summary"))
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- add `examples/calendar_today.py` to show how to fetch today's events
- document example usage in README

## Testing
- `pip install -r requirements.txt`
- `pip install pytest-asyncio`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b37b4cc308330b9b0070bb4b9bdfe