### PR TITLE
Implement weekend_trigger v1.1

### DIFF
--- a/tests/test_main_handler.py
+++ b/tests/test_main_handler.py
@@ -82,26 +82,22 @@ async def test_weekend_trigger(monkeypatch):
             ]
 
     class DummyCal:
-        def __init__(self):
-            self.calls = 0
-
         async def get_events(self, start, end, tz=None):
-            self.calls += 1
-            if self.calls == 1:
-                return [
-                    {"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}}
-                ]
             return [
-                {"summary": "来週会議", "start": {"dateTime": "2025-06-25T09:00:00"}}
+                {"summary": "会議", "start": {"dateTime": "2025-06-18T10:00:00"}}
             ]
 
     class DummyHealth:
-        async def latest(self):
-            return {}
+        async def period(self, start, end):
+            return [
+                {"タイムスタンプ": "2025-06-17", "気分": "普通", "睡眠時間": 6}
+            ]
 
     class DummyWork:
-        async def latest(self):
-            return {}
+        async def period(self, start, end):
+            return [
+                {"タイムスタンプ": "2025-06-17", "今日のまとめ！": "会議準備"}
+            ]
 
     monkeypatch.setattr("monday_secretary.main_handler.TasksClient", DummyTasks)
     monkeypatch.setattr("monday_secretary.main_handler.CalendarClient", DummyCal)
@@ -111,6 +107,8 @@ async def test_weekend_trigger(monkeypatch):
     reply = await handle_message("週末整理して")
     assert "T1" in reply
     assert "T3" in reply
-    assert "T2" not in reply
-    assert "来週会議" in reply
+    assert "T2" in reply
+    assert "会議" in reply
+    assert "気分:普通" in reply
+    assert "会議準備" in reply
 


### PR DESCRIPTION
## Summary
- enhance `weekend_trigger` to summarize unfinished tasks, events, health logs and work notes
- update tests for new weekend workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6870af87bdc083308423ae26793de683